### PR TITLE
Mrs/ci windows mingw

### DIFF
--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -1,0 +1,43 @@
+name: 'tests Windows'
+
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+
+jobs:
+  mingw:
+
+    runs-on: windows-latest
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64 # Start a 64 bit Mingw environment
+          update: true
+
+      - name: Install dependencies
+        run: |
+          C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm --needed git make"
+          C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm --needed mingw-w64-x86_64-{toolchain,ffmpeg}"
+          C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm mingw-w64-x86_64-python3-pip"
+          C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm --needed mingw-w64-x86_64-meson"
+
+      - name: Setup
+        run: |
+          $env:CHERE_INVOKING = 'yes'
+          C:\msys64\usr\bin\bash -lc "meson setup builddir"
+
+      - name: Build
+        run: |
+          $env:CHERE_INVOKING = 'yes'
+          C:\msys64\usr\bin\bash -lc "meson compile -C builddir"
+
+      - name: Test
+        run: |
+          $env:CHERE_INVOKING = 'yes'
+          C:\msys64\usr\bin\bash -lc "meson test -C builddir"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![tests Linux](https://github.com/stupeflix/sxplayer/workflows/tests%20Linux/badge.svg)
 ![tests Mac](https://github.com/stupeflix/sxplayer/workflows/tests%20Mac/badge.svg)
+![tests Windows](https://github.com/stupeflix/sxplayer/workflows/tests%20Windows/badge.svg)
 
 ## Introduction
 


### PR DESCRIPTION
### Description:

This PR is based on [PR](https://github.com/Stupeflix/sxplayer/pull/7/files ) and alllows to abstract from dependencies issues to validate Meson part.
This workflow provides a CI that:
	- use **msys2** tool
	- use 64 bit **Mingw** backend to trigger dependencies (especially ffmpeg) libs
	- use **Meson**

=>  build and tests OK 

### Encountered problems:

- Incompatibility python from msys with meson
-- Error:
`ERROR: This python3 seems to be msys/python on MSYS2 Windows, which is known to have path semantics incompatible with Meson
ERROR: Please install and use mingw-w64-i686-python3 and/or mingw-w64-x86_64-python3 with Pacman`
-- [doc](https://mesonbuild.com/Getting-meson.html)
-- Solved by using native `win64meson ` instead of msys2 meson from pacman

- What didn't work:
```
mingw-w64-x86_64-{toolchain,ffmpeg, python3-pip}
mingw-w64-x86_64-{toolchain,ffmpeg, python}
mingw-w64-x86_64-{toolchain,ffmpeg, python3}
```
=> The link with ffmpeg is not done

- Usage of `CHERE_INVOKING` variable
It can be factorized by using `echo "::set-env name=CHERE_INVOKING::'yes'"` 
but the `set-env` command is deprecated, the new way of doing [that](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files) makes just an instanciation and we are forced to call the variable after so it's still redondant.

