### PR TITLE
ci: complete github action workflow ci_win.yml file

### DIFF
--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm --needed git make"
+          C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm --needed git"
           C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm --needed mingw-w64-x86_64-{toolchain,ffmpeg}"
           C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm mingw-w64-x86_64-python3-pip"
           C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm --needed mingw-w64-x86_64-meson"

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -41,3 +41,44 @@ jobs:
         run: |
           $env:CHERE_INVOKING = 'yes'
           C:\msys64\usr\bin\bash -lc "meson test -C builddir"
+
+  msvc:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+        architecture: 'x64'
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        git clone --depth 1 https://github.com/Microsoft/vcpkg
+        cd vcpkg
+        ./bootstrap-vcpkg.bat -disableMetrics
+        vcpkg install pthread:x64-windows ffmpeg:x64-windows
+        vcpkg integrate install
+        pip install meson
+
+    - name: Setup
+      shell: cmd
+      run: |
+        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 && ^
+        meson setup builddir --backend vs --buildtype release --default-library static ^
+        --pkg-config-path "D:\a\sxplayer\sxplayer\vcpkg\installed\x64-windows\lib\pkgconfig"
+
+    - name: Build
+      shell: cmd
+      run: |
+        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 && ^
+        meson compile -C builddir
+
+    - name: Test
+      shell: cmd
+      run: |
+        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 && ^
+        meson test -C builddir


### PR DESCRIPTION
# Description

This PR follows and completes this [one](https://github.com/Stupeflix/sxplayer/pull/9).
It  adds a new CI workflow that:
 - doesn't use **msys2** tool
- trigger needed dependencies with a windows package manager called **vcpkg** 
- use **Microsoft Visual Studio Backend** (no Ninja backend, no MinGW64 backend) essential to link with Microsoft frameworks
 - use **Meson** (instead previously _Makefile_) to:
          -   build sxplayer lib
          -   run sxplayer tests
  
=>  build and tests **OK**

# Times

- Install dependencies (ffmpeg + vcpkg + meson + pthread + python) < 45min
- Setup < 1min
- Build < 1min
- Tests < 3min

# Encountered problems

## About Visual Studio part:

- To be able to use the `--backend vs` command line option from meson, the *Visual Studio Command Prompt Open x64 Native Tools Command Prompt* must be opened. 
Either you get:
 ` meson.build:1:0: ERROR: Could not detect Visual Studio: Environment variable VSINSTALLDIR is not set!`

- Pitfall is that you _don't have_ to set the variable `VSINSTALLDIR`

- A proper way of calling meson with VS backend is:
`"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" && meson setup builddir --backend vs`  

- The two commands must be well written on the same line with an ampersand. Note that you lost focus after that line so you need one following block per VS command:
```
    - name: Setup
      shell: cmd
      run: "C:\Program Files ...
```
 
- We well get in the logs the message:
`Auto detected Visual Studio backend: vs2019`

- We also get the good compiler (**cl**):
`C compiler for the host machine: cl (msvc 19.27.29112 "Microsoft (R) C/C++ Optimizing Compiler Version 19.27.29112 for x86")`

- Pitfall is that the message: `Auto detected Visual Studio backend: vs2019` is also well displayed if you:
`set VSINSTALLDIR="C:\Program Files (x86)\Microsoft Visual Studio\2019"`

But it's a false alarm since the compiler is not the correct detected one (**gcc**):
`C linker for the host machine: gcc ld.bfd 2.30` 

It provides this kind of errors: `KeyError: 'b_vscrt'` see [issue_1](https://github.com/mesonbuild/meson/issues/6758
), [issue_2](https://github.com/mesonbuild/meson/issues/4273)

- Note that calling VS with _Community_ or _Professional_ keywords into the path for example like that  : 
       - `C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat`
       - ` C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\Common7\Tools\VsDevCmd.bat`

doesn't work: only paths containing _Enterprise_ keyword are recognized.

Indeed, on the host computer, in `C:/Program Files (x86)` directory there are these VS versions:
                  - `Microsoft Visual Studio/2019/`
                  - `Microsoft Visual Studio 10.0`
                  - `Microsoft Visual Studio 11.0`
                  - `Microsoft Visual Studio 12.0`
                  - `Microsoft Visual Studio 14.0`

Note that these versions are in `Enterprise` single repository (`Community` and `Professional` repositories are mentioned often on the web but not available in our cases).

Note also that there is only 2019 version (no 2017, 2015, etc) and `BuildTools` are also not available (useful to test paths like that for example: ` "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat" `)

Note that double quotes around path `"C:\Program Files (x86)\Microsoft..."` is essential, it doesn't work without it.

## About dependencies during setup step

The idea was to get sxplayer dependencies independently of the toolchain mingw.

To install **ffmpeg** I explored:

- *chocolatey* package manager => it doesn't provides `.pc` files. It is useful to use ffmpeg `exe` but not for dev stuffs.
- *conan* with [build helper](https://docs.conan.io/en/latest/reference/build_helpers/meson.html)  => didn't succeed to use it properly.
- *home-made python script* `get-ffmpeg-for-windows.py` ( with usage of python function `urlretrieve`) that trigger and build sources => I didn't succeed.
- *vcpkg* package manager => good chosen solution because it simple and provides `.pc` files
	- It works in few lines just like that:
        - `git clone https://github.com/Microsoft/vcpkg.git`
        - `cd vcpkg`
        - `./bootstrap-vcpkg.bat -disableMetrics`
        - `vcpkg install ffmpeg[ffmpeg,ffplay,nonfree,avresample]:x64-windows`
	- The flag `-disableMetrics` allows to opt-out  data collection (vcpkg telemetry feature is enabled by default)
	- It takes around 40min to build ffmpeg /!\
	- `vcpkg list` command gives all installed package: `ffmpeg:x64-windows   4.3.1#4 fmpeg[avcodec]:x86-windows ffmpeg[avdevice]:x64-windows ffmpeg[avfilter]:x64-windows ffmpeg[avformat]:x86-windows...`

	-  The ffmpeg libraires are generated here (pathexamples for _avcodec_) :
                  `./packages/ffmpeg_x64-windows/debug/lib/avcodec.lib`
                 `./packages/ffmpeg_x64-windows/lib/avcodec.lib`
                  `./buildtrees/ffmpeg/x64-windows-dbg/libavcodec/avcodec.lib`
                  `./buildtrees/ffmpeg/x64-windows-rel/libavcodec/avcodec.lib`
                  `./installed/x64-windows/debug/lib/avcodec.lib`
                  `./installed/x64-windows/lib/avcodec.lib`

	- The package config `.pc` files are generated here (path examples for _avcodec_) :
                `./buildtrees/ffmpeg/x64-windows-dbg/libavcodec/libavcodec.pc`
                `./buildtrees/ffmpeg/x64-windows-rel/libavcodec/libavcodec.pc`
                `./installed/x64-windows/debug/lib/pkgconfig/libavcodec.pc`
                `./installed/x64-windows/lib/pkgconfig/libavcodec.pc`
                `./packages/ffmpeg_x64-windows/debug/lib/pkgconfig/libavcodec.pc`
                `./packages/ffmpeg_x64-windows/lib/pkgconfig/libavcodec.pc`

	- Note that previous paths are relative to: `D:/a/sxplayer/sxplayer/vcpkg` directory creating during `vcpkg` installation.

## About making meson consume ffmpeg libs

This was a tricky part: meson didn't find ffmpegs libs (_libavformat.pc, libavcodec.pc, etc_) with error: 
` Run-time dependency libavformat found: NO (tried cmake)`

I tried several ways to make meson hints the internal build library ffmpeg:

- I played with environment variables:
	- `set LIB="see paths containing *.lib above"`
	- `set LIBPATH="see path containing *.lib above"`
	- `set LIBDIR="see path containing *.lib above"`
	- `set PKG_CONFIG_PATH="see paths containing *.pc above"`

- Using `find_library` instead `dependency` into the meson file with a static ffmpeg version:
	- ex: `  cc.find_library('libavformat', dirs : meson.current_source_dir() + 'vcpkg\packages\ffmpeg_x64-windows-static\lib')`
	 - [related_issue](https://github.com/mesonbuild/meson/issues/4029)

- The good way is to use:
     - an **absolute** path
     - a `cmd` **shell** (not bash!) 
     - Windows paths (containing \ not /)
     - it works like:
          - `set PKG_CONFIG_PATH=D:\a\sxplayer\sxplayer\vcpkg\installed\x64-windows\lib\pkgconfig;%PKG_CONFIG_PATH%;`
     - Note that it doesn't work with double quotes around the path "D:\a\sxplay..."
     - It also works like that:
          - `meson setup builddir --backend vs --pkg-config-path "D:\a\sxplayer\sxplayer\vcpkg\installed\x64-windows\lib\pkgconfig"`

## About meson compilation part

- I got this **meson error**:
`KeyError: 'PLATFORM'`
So after looking at  [meson sources](https://fossies.org/linux/meson/mesonbuild/mcompile.py):
  ` # Remove platform from env so that msbuild does not pick x86 platform when solution platform is Win32`
  ` env = os.environ.copy()`
  `  del env['PLATFORM']`
  
I just assigned `PLATFORM` environnement variable with an empty string like that:
` set PLATFORM=""`
It appears both for `x64` and `x86`.
=> should I report that to meson project?  It's a bit weird to delete a variable before checking existence.


- I got this **header error**:
        ` async.c(21,10): fatal error C1083: Cannot open include file: 'pthread.h': No such file or directory`
Indeed, the file `pthread.h` was missing.
        I installed `pthread` with vcpkg manager (it installs `pthreads` too btw): the headers were now present here:
               `./installed/x64-windows/include/pthread.h`
               `./packages/pthreads_x64-windows/include/pthread.h`
           But still not found.
           I tried to set paths set manually  [see stackoverflow](https://stackoverflow.com/questions/19467455/how-to-set-up-pthreads-on-windows)
                   - `set INCLUDE=D:\a\sxplayer\sxplayer\vcpkg\installed\x64-windows\include;%INCLUDE%`
                   - `set LIB=D:\a\sxplayer\sxplayer\vcpkg\installed\x64-windows\lib;%LIB%`
 
- Finally the trick was not to setup paths but use this command:
`vcpkg integrate install`
It helps for headers and libraries to be found.
In the logs this message appears:
```Applied user-wide integration for this vcpkg root.
All MSBuild C++ projects can now #include any installed libraries.
Linking will be handled automatically.
Installing new libraries will make them instantly available.
```
 
- I got this **header error**:
         `async.c(23,10): fatal error C1083: Cannot open include file: 'libavcodec/avcodec.h'`
The headers were correctly present here: 
                 `./installed/x64-windows/include/libavcodec/avcodec.h`
                 `./packages/ffmpeg_x64-windows/include/libavcodec/avcodec.h`

Use `vcpkg integrate install` solved the issue similar as `pthread` but only for ffmpeg _dynamic_.
It didn't work in _static_ ffmpeg mode.

- I got this **link error**: 
         `LINK : fatal error LNK1104: cannot open file 'sxplayer.lib'`

 I searched for the **dll** and they are well in the _builddir_ create during `meson setup`:
                  `D:\a\sxplayer\sxplayer\builddir\avformat-58.dll`
                  `D:\a\sxplayer\sxplayer\builddir\avcodec-58.dll`
                  `D:\a\sxplayer\sxplayer\builddir\swresample-3.dll`
                  `D:\a\sxplayer\sxplayer\builddir\avutil-56.dll`
                  `D:\a\sxplayer\sxplayer\builddir\avfilter-7.dll`
                  `D:\a\sxplayer\sxplayer\builddir\swscale-5.dll`
                  `D:\a\sxplayer\sxplayer\builddir\postproc-55.dll`
                 `D:\a\sxplayer\sxplayer\builddir\avresample-4.dll`
                 `D:\a\sxplayer\sxplayer\builddir\pthreadVC3.dll`

I also tried without success to add dependencies _lib_ and _bin_ in the path:
              `set PATH=D:\a\sxplayer\sxplayer\vcpkg\packages\ffmpeg_x64-windows\lib;%PATH%`
              `set PATH=D:\a\sxplayer\sxplayer\vcpkg\installed\x64-windows\lib;%PATH%`
              `set PATH=D:\a\sxplayer\sxplayer\vcpkg\packages\ffmpeg_x64-windows\bin;%PATH%`
              `set PATH=D:\a\sxplayer\sxplayer\vcpkg\installed\x64-windows\bin;%PATH%`
        
I saw that the issue was during the compilation of `test-prog.c` which firstly include `"sxplayer.h"` so the `sxplayer.lib` was not found.
Building without the `test-prog` part at the end of the `meson` file was OK.

However, stuffs were well generated into the _builddir_:
          `sxplayer.h`
          `sxplayer.sln`
         `sxplayer@sha.vcxproj`
         `test-prog@exe.vcxproj`
         `sxplayer-9.dll`

Adding _builddir_ into the path to help to find `sxplayer-9.dll` didn't work neither.
Use `declare_dependency` or `find_library` or `include_directories` into the meson file didn't work neither.

What solved the issue is to build target (sxplayer librarie) in `static` mode.
It provides `libsxplayer.a` instead `sxplayer.dll`.
This step has to be done during step like that:
` meson setup builddir --backend vs --default-library static`

 
- I also choose to use **release** instead _debug_ configuration for meson:
`meson setup builddir --backend vs --buildtype release`
To be in tune with what was done on linux and mac CI.

- I also got **some warnings**: 
    -  `sxplayer.c(80,1): warning C4305: 'initializing': truncation from 'unsigned __int64' to 'double']`
     - `test-prog.c(498,1): warning C4305: 'initializing': truncation from 'double' to 'const float']`
    - Note that it's different warning that with mingw backend.
    - It appears on `x86` and `x64`.

## About architecture
 
I saw inconsistent logs that referenced different architectures (x86/32 bits and x64/64bits).
So, for more clarity I specified _x64_ on each tool (python, packages vcpkg, visual studio code). 
Hence, we are sure we build lib with the 64-bit Visual Studio toolchain/SDK and the output binary will be ok for 64 bit execution.
 
I also replaced:
 `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"`
by:
 `"C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64` 
in order to be able to specify `x64`.     

By the way it solved the previous issue with the variable `PLATFORM` not anymore needed.

I well got in log:
 `[vcvarsall.bat] Environment initialized for: 'x64'`
and
`Building solution configuration "release|x64".`

So there is no more ambiguous mixing configurations: the host architecture and targets are well defined.
The logs for each tools are:
         - `C:\hostedtoolcache\windows\Python\3.9.0\x64\python.EXE` (python)
         - `Host machine cpu family: x86_64` (meson)
         - Note that `set VCPKG_DEFAULT_TRIPLET=x64-windows` or `set VCPKG_TARGET_ARCHITECTURE=x64` doesn't work, it always selected `x86` per default, we must specify manually like that: `packagename:x64-windows`

Note that the CI works in `x86` and in `x64` architecture, we the same measure average times, for `x86` we obtain these kind of logs:
```Host machine cpu family: x86
Building solution configuration "release|Win32". 
kernel32.lib 
```
 I kept the most recent processor architecture _i.e_  64 bits for the workflow since Microsoft has quit 32 bits systems and applications.
 

 
# Ressources

https://mesonbuild.com/Using-with-Visual-Studio.html#using-with-visual-studio
https://github.com/microsoft/vcpkg#tab-completion--auto-completion
https://mesonbuild.com/Builtin-options.html
https://docs.godotengine.org/en/3.0/development/compiling/compiling_for_windows.html
https://www.appveyor.com/docs/lang/cpp/
https://vcpkg.readthedocs.io/en/latest/about/faq/
https://github.com/mesonbuild/meson/blob/2455fc4e6ff3d7b329a2cb25b95b5b12c9887647/ci/azure-steps.yml

