### PR TITLE
Symbol export

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -26,6 +26,13 @@ jobs:
         meson setup --buildtype release builddir --default-library static
         meson test -C builddir -v
 
+    - name: Upload Logs
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: linux-static-logs
+        path: builddir/meson-logs
+
   linux-shared:
 
     runs-on: ubuntu-20.04
@@ -44,6 +51,13 @@ jobs:
       run: |
         meson setup --buildtype release builddir --default-library shared
         meson test -C builddir -v
+
+    - name: Upload Logs
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: linux-shared-logs
+        path: builddir/meson-logs
 
   valgrind:
 

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  linux:
+  linux-static:
 
     runs-on: ubuntu-20.04
 
@@ -23,7 +23,26 @@ jobs:
 
     - name: Run tests
       run: |
-        meson setup --buildtype release builddir
+        meson setup --buildtype release builddir --default-library static
+        meson test -C builddir -v
+
+  linux-shared:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        sudo apt -y update
+        sudo apt -y install meson ninja-build
+        sudo apt -y install libglfw3-dev libglew-dev
+        sudo apt -y install libavcodec-dev libavutil-dev libavformat-dev libavdevice-dev libavfilter-dev libswscale-dev libswresample-dev libpostproc-dev
+
+    - name: Run tests
+      run: |
+        meson setup --buildtype release builddir --default-library shared
         meson test -C builddir -v
 
   valgrind:

--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  macos:
+  macos-static:
 
     runs-on: macos-latest
 
@@ -23,5 +23,24 @@ jobs:
 
     - name: Run tests
       run: |
-        meson setup --buildtype release builddir
+        meson setup --buildtype release builddir --default-library static
+        meson test -C builddir -v
+
+  macos-shared:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        brew install meson ninja
+        brew install glfw3 glew
+        brew install ffmpeg
+        brew install pkg-config
+
+    - name: Run tests
+      run: |
+        meson setup --buildtype release builddir --default-library shared
         meson test -C builddir -v

--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -26,6 +26,13 @@ jobs:
         meson setup --buildtype release builddir --default-library static
         meson test -C builddir -v
 
+    - name: Upload Logs
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: macos-static-logs
+        path: builddir/meson-logs
+
   macos-shared:
 
     runs-on: macos-latest
@@ -44,3 +51,10 @@ jobs:
       run: |
         meson setup --buildtype release builddir --default-library shared
         meson test -C builddir -v
+
+    - name: Upload Logs
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: macos-shared-logs
+        path: builddir/meson-logs

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  mingw:
+  mingw-static:
 
     runs-on: windows-latest
 
@@ -30,7 +30,7 @@ jobs:
       - name: Setup
         run: |
           $env:CHERE_INVOKING = 'yes'
-          C:\msys64\usr\bin\bash -lc "meson setup builddir"
+          C:\msys64\usr\bin\bash -lc "meson setup builddir --default-library static"
 
       - name: Build
         run: |
@@ -42,7 +42,44 @@ jobs:
           $env:CHERE_INVOKING = 'yes'
           C:\msys64\usr\bin\bash -lc "meson test -C builddir"
 
-  msvc:
+
+  mingw-shared:
+
+    runs-on: windows-latest
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64 # Start a 64 bit Mingw environment
+          update: true
+
+      - name: Install dependencies
+        run: |
+          C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm --needed git"
+          C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm --needed mingw-w64-x86_64-{toolchain,ffmpeg}"
+          C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm mingw-w64-x86_64-python3-pip"
+          C:\msys64\usr\bin\bash -lc "pacman -S --noconfirm --needed mingw-w64-x86_64-meson"
+
+      - name: Setup
+        run: |
+          $env:CHERE_INVOKING = 'yes'
+          C:\msys64\usr\bin\bash -lc "meson setup builddir --default-library shared"
+
+      - name: Build
+        run: |
+          $env:CHERE_INVOKING = 'yes'
+          C:\msys64\usr\bin\bash -lc "meson compile -C builddir"
+
+      - name: Test
+        run: |
+          $env:CHERE_INVOKING = 'yes'
+          C:\msys64\usr\bin\bash -lc "meson test -C builddir"
+
+
+  msvc-static:
 
     runs-on: windows-latest
 
@@ -69,6 +106,48 @@ jobs:
       run: |
         "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 && ^
         meson setup builddir --backend vs --buildtype release --default-library static ^
+        --pkg-config-path "D:\a\sxplayer\sxplayer\vcpkg\installed\x64-windows\lib\pkgconfig"
+
+    - name: Build
+      shell: cmd
+      run: |
+        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 && ^
+        meson compile -C builddir
+
+    - name: Test
+      shell: cmd
+      run: |
+        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 && ^
+        meson test -C builddir
+
+
+  msvc-shared:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+        architecture: 'x64'
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        git clone --depth 1 https://github.com/Microsoft/vcpkg
+        cd vcpkg
+        ./bootstrap-vcpkg.bat -disableMetrics
+        vcpkg install pthread:x64-windows ffmpeg:x64-windows
+        vcpkg integrate install
+        pip install meson
+
+    - name: Setup
+      shell: cmd
+      run: |
+        "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 && ^
+        meson setup builddir --backend vs --buildtype release --default-library shared ^
         --pkg-config-path "D:\a\sxplayer\sxplayer\vcpkg\installed\x64-windows\lib\pkgconfig"
 
     - name: Build

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -42,6 +42,13 @@ jobs:
           $env:CHERE_INVOKING = 'yes'
           C:\msys64\usr\bin\bash -lc "meson test -C builddir"
 
+      - name: Upload Logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: mingw-static-logs
+          path: builddir/meson-logs
+
 
   mingw-shared:
 
@@ -77,6 +84,13 @@ jobs:
         run: |
           $env:CHERE_INVOKING = 'yes'
           C:\msys64\usr\bin\bash -lc "meson test -C builddir"
+
+      - name: Upload Logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: mingw-shared-logs
+          path: builddir/meson-logs
 
 
   msvc-static:
@@ -120,6 +134,13 @@ jobs:
         "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 && ^
         meson test -C builddir
 
+    - name: Upload Logs
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: msvc-static-logs
+        path: builddir/meson-logs
+
 
   msvc-shared:
 
@@ -161,3 +182,10 @@ jobs:
       run: |
         "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 && ^
         meson test -C builddir
+
+    - name: Upload Logs
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: msvc-shared-logs
+        path: builddir/meson-logs

--- a/libsxplayer.darwin.symexport
+++ b/libsxplayer.darwin.symexport
@@ -1,1 +1,0 @@
-_sxplayer_*

--- a/libsxplayer.symexport
+++ b/libsxplayer.symexport
@@ -1,4 +1,0 @@
-LIBSXPLAYER {
-	global: sxplayer_*;
-	local: *;
-};

--- a/meson.build
+++ b/meson.build
@@ -92,10 +92,10 @@ lib_src = files(
   'src/utils.c',
 )
 
-lib_link_args = cc.get_supported_link_arguments([
-  '-Wl,--version-script,@0@'.format(meson.current_source_dir() / 'libsxplayer.symexport'),  # GNU ld
-  '-Wl,-exported_symbols_list,@0@'.format(meson.current_source_dir() / 'libsxplayer.darwin.symexport'),  # Darwin
-])
+lib_c_args = []
+if get_option('default_library') == 'shared'
+  lib_c_args += '-DBUILD_SXPLAYER_SHARED_LIB'
+endif
 
 if host_system == 'darwin'
   lib_src += files('src/decoder_vt.c')
@@ -108,7 +108,8 @@ libsxplayer = library(
   install: true,
   install_rpath: install_rpath,
   version: meson.project_version(),
-  link_args: lib_link_args,
+  c_args: lib_c_args,
+  gnu_symbol_visibility: 'hidden',
 )
 
 lib_header = configure_file(
@@ -122,10 +123,16 @@ if get_option('cpp-header')
 endif
 
 pkg = import('pkgconfig')
+pkg_extra_cflags = []
+if get_option('default_library') == 'static'
+  pkg_extra_cflags += '-DUSE_SXPLAYER_STATIC_LIB'
+endif
+
 pkg.generate(
   libsxplayer,
   name: 'libsxplayer',  # not specifying the name would fallback on "sxplayer.pc" instead of "libsxplayer.pc"
   description: 'Stupeflix Player library',
+  extra_cflags: pkg_extra_cflags,
 )
 
 
@@ -186,6 +193,11 @@ if get_option('tests')
       dependencies: lib_deps,
       link_with: libsxplayer,
       install: false,
+      # pkg-config extra cflags don't apply to local executables, so we have to
+      # transfer them manually. Alternatively, we could create a virtual
+      # dependency and use it.
+      # See https://github.com/mesonbuild/meson/issues/8082 for more information
+      c_args: pkg_extra_cflags,
     )
     executables += {exe_name: exe}
   endforeach

--- a/src/sxplayer.h.in
+++ b/src/sxplayer.h.in
@@ -34,6 +34,18 @@
                                                   SXPLAYER_VERSION_MINOR, \
                                                   SXPLAYER_VERSION_MICRO)
 
+#if defined(_WIN32)
+#  if defined(BUILD_SXPLAYER_SHARED_LIB) /* On Windows, we need to export the symbols while building */
+#    define SXAPI __declspec(dllexport)
+#  elif defined(USE_SXPLAYER_STATIC_LIB) /* Static library users don't need anything special */
+#    define SXAPI
+#  else
+#    define SXAPI __declspec(dllimport)  /* Dynamic library users (default) need a DLL import spec */
+#  endif
+#else
+#  define SXAPI __attribute__((visibility("default"))) /* This cancel the hidden GNU symbol visibility attribute */
+#endif
+
 /* Stupeflix Media Player */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
@@ -192,7 +204,7 @@ struct sxplayer_info {
  *
  * @param filename media input file name
  */
-struct sxplayer_ctx *sxplayer_create(const char *filename);
+SXAPI struct sxplayer_ctx *sxplayer_create(const char *filename);
 
 /**
  * Type of the user log callback
@@ -219,7 +231,7 @@ typedef void (*sxplayer_log_callback_type)(void *arg, int level, const char *fil
  *                  the callback
  * @param callback  custom user logging callback
  */
-void sxplayer_set_log_callback(struct sxplayer_ctx *s, void *arg, sxplayer_log_callback_type callback);
+SXAPI void sxplayer_set_log_callback(struct sxplayer_ctx *s, void *arg, sxplayer_log_callback_type callback);
 
 /**
  * Set an option.
@@ -246,19 +258,19 @@ void sxplayer_set_log_callback(struct sxplayer_ctx *s, void *arg, sxplayer_log_c
  *   stream_idx               integer   force a stream number instead of picking the "best" one (note: stream MUST be of type avselect)
  *   use_pkt_duration         integer   use packet duration instead of decoding the next frame to get the next frame pts
  */
-int sxplayer_set_option(struct sxplayer_ctx *s, const char *key, ...);
+SXAPI int sxplayer_set_option(struct sxplayer_ctx *s, const char *key, ...);
 
 /**
  * Get the media duration (clipped to trim_duration if set).
  *
  * The duration is expressed in seconds.
  */
-int sxplayer_get_duration(struct sxplayer_ctx *s, double *duration);
+SXAPI int sxplayer_get_duration(struct sxplayer_ctx *s, double *duration);
 
 /**
  * Get various information on the media.
  */
-int sxplayer_get_info(struct sxplayer_ctx *s, struct sxplayer_info *info);
+SXAPI int sxplayer_get_info(struct sxplayer_ctx *s, struct sxplayer_info *info);
 
 /**
  * Get the frame at an absolute time.
@@ -276,12 +288,12 @@ int sxplayer_get_info(struct sxplayer_ctx *s, struct sxplayer_info *info);
  * The function is blocking, it will make sure any asynchronous operation
  * previously requested (start, seek, stop) is honored before returning.
  */
-struct sxplayer_frame *sxplayer_get_frame(struct sxplayer_ctx *s, double t);
+SXAPI struct sxplayer_frame *sxplayer_get_frame(struct sxplayer_ctx *s, double t);
 
 /**
  * Same as sxplayer_get_frame, but with timestamp expressed in microseconds.
  */
-struct sxplayer_frame *sxplayer_get_frame_ms(struct sxplayer_ctx *s, int64_t ms);
+SXAPI struct sxplayer_frame *sxplayer_get_frame_ms(struct sxplayer_ctx *s, int64_t ms);
 
 /**
  * Request a playback start to the player.
@@ -291,7 +303,7 @@ struct sxplayer_frame *sxplayer_get_frame_ms(struct sxplayer_ctx *s, int64_t ms)
  *
  * Return 0 on success, a negative value on error.
  */
-int sxplayer_start(struct sxplayer_ctx *s);
+SXAPI int sxplayer_start(struct sxplayer_ctx *s);
 
 /**
  * Request a stop to the player to liberate playback ressources.
@@ -301,7 +313,7 @@ int sxplayer_start(struct sxplayer_ctx *s);
  *
  * Return 0 on success, a negative value on error.
  */
-int sxplayer_stop(struct sxplayer_ctx *s);
+SXAPI int sxplayer_stop(struct sxplayer_ctx *s);
 
 /**
  * Request a seek to the player at a given time.
@@ -313,7 +325,7 @@ int sxplayer_stop(struct sxplayer_ctx *s);
  *
  * Return 0 on success, a negative value on error.
  */
-int sxplayer_seek(struct sxplayer_ctx *s, double t);
+SXAPI int sxplayer_seek(struct sxplayer_ctx *s, double t);
 
 /**
  * Get the next frame.
@@ -328,15 +340,15 @@ int sxplayer_seek(struct sxplayer_ctx *s, double t);
  * interested in. You can still use this function in combination with
  * sxplayer_get_frame() in case you need seeking.
  */
-struct sxplayer_frame *sxplayer_get_next_frame(struct sxplayer_ctx *s);
+SXAPI struct sxplayer_frame *sxplayer_get_next_frame(struct sxplayer_ctx *s);
 
 /* Enable or disable the droping of non reference frames */
-int sxplayer_set_drop_ref(struct sxplayer_ctx *s, int drop);
+SXAPI int sxplayer_set_drop_ref(struct sxplayer_ctx *s, int drop);
 
 /* Release a frame obtained with sxplayer_get_frame() */
-void sxplayer_release_frame(struct sxplayer_frame *frame);
+SXAPI void sxplayer_release_frame(struct sxplayer_frame *frame);
 
 /* Close and free everything */
-void sxplayer_free(struct sxplayer_ctx **ss);
+SXAPI void sxplayer_free(struct sxplayer_ctx **ss);
 
 #endif


### PR DESCRIPTION
This PR reworks https://github.com/Stupeflix/sxplayer/pull/16 with the following changes:
- removed extra line break added in ci_linux: this was marked in red by Git
- re-ordered a few logs uploading instruction in the CI so that they are consistently at the end of the jobs
- added logs upload for MSVC
- cosmetics in the meson.build (unneeded line breaks, missing trailing comma, ...)
- simplified transferring arguments to the test executable
- clarified the reason for explicitly transferring flags to tests
- added explanation in the public header because this is for our end users
- squashed together 2 commits that couldn't work without each other
- completely rewrote the commit description to elaborate on the what/why/how
- rewrote commit message and description of the log uploading commit