### PR TITLE
ci: windows ci uses dependencies from artifact instead build it

### DIFF
--- a/.github/workflows/ci_dep_build.yml
+++ b/.github/workflows/ci_dep_build.yml
@@ -2,10 +2,6 @@ name: 'Dependencies build Windows'
 on:
   schedule:
   - cron: "0 0 1 * *"
-  push:
-    branches:
-      - 'master'
-  pull_request:
 
 jobs:
   dependencies:

--- a/.github/workflows/ci_dep_build.yml
+++ b/.github/workflows/ci_dep_build.yml
@@ -1,0 +1,30 @@
+name: 'Dependencies build Windows'
+on:
+  schedule:
+  - cron: "0 0 1 * *"
+  push:
+    branches:
+      - 'master'
+  pull_request:
+
+jobs:
+  dependencies:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build dependencies
+      shell: bash
+      run: |
+        git clone --depth 1 https://github.com/Microsoft/vcpkg
+        cd vcpkg
+        ./bootstrap-vcpkg.bat -disableMetrics
+        vcpkg install pthread:x64-windows ffmpeg:x64-windows
+
+    - name: Upload dependencies
+      uses: actions/upload-artifact@v2
+      with:
+        name: vcpkg
+        path: D:\a\sxplayer\sxplayer\vcpkg

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -105,13 +105,18 @@ jobs:
         python-version: '3.x'
         architecture: 'x64'
 
+    - name: Download dependencies
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: ci_dep_build.yml
+        name: vcpkg
+        path: vcpkg
+
     - name: Install dependencies
       shell: bash
       run: |
-        git clone --depth 1 https://github.com/Microsoft/vcpkg
         cd vcpkg
         ./bootstrap-vcpkg.bat -disableMetrics
-        vcpkg install pthread:x64-windows ffmpeg:x64-windows
         vcpkg integrate install
         pip install meson
 
@@ -154,13 +159,18 @@ jobs:
         python-version: '3.x'
         architecture: 'x64'
 
+    - name: Download dependencies
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        workflow: ci_dep_build.yml
+        name: vcpkg
+        path: vcpkg
+
     - name: Install dependencies
       shell: bash
       run: |
-        git clone --depth 1 https://github.com/Microsoft/vcpkg
         cd vcpkg
         ./bootstrap-vcpkg.bat -disableMetrics
-        vcpkg install pthread:x64-windows ffmpeg:x64-windows
         vcpkg integrate install
         pip install meson
 


### PR DESCRIPTION
rebased on/must be merged after https://github.com/Stupeflix/sxplayer/pull/20
