### PR TITLE
ci: fix ci schedule

### DIFF
--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -6,7 +6,7 @@ on:
       - 'master'
   pull_request:
   schedule:
-      - cron: "0 * * * 6"  # Run every Saturday at midnight
+      - cron: "0 0 * * 6"  # Run every Saturday at midnight
 
 jobs:
   mingw-static:


### PR DESCRIPTION
ci workflow is runned at minute 0 **every hours** on Saturday.
Now it will be runned at 00:00 on Saturday so only **once**.