### PR TITLE
internal: add pthread compatibility header

### DIFF
--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -168,7 +168,7 @@ jobs:
       shell: bash
       run: |
         pip install meson
-    
+
     - name: Install dependencies via vcpkg
       uses: lukka/run-vcpkg@v6
       with:

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -117,7 +117,7 @@ jobs:
       with:
         vcpkgGitCommitId: 595777db2332a3442b73f9af9f656355f207aec9
         vcpkgTriplet: x64-windows
-        vcpkgArguments: pthreads ffmpeg[ffmpeg]
+        vcpkgArguments: ffmpeg[ffmpeg]
         cleanAfterBuild: false
 
     - name: vcpkg integrate install
@@ -174,7 +174,7 @@ jobs:
       with:
         vcpkgGitCommitId: 595777db2332a3442b73f9af9f656355f207aec9
         vcpkgTriplet: x64-windows
-        vcpkgArguments: pthreads ffmpeg[ffmpeg]
+        vcpkgArguments: ffmpeg[ffmpeg]
         cleanAfterBuild: false
 
     - name: vcpkg integrate install

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -120,11 +120,6 @@ jobs:
         vcpkgArguments: ffmpeg[ffmpeg]
         cleanAfterBuild: false
 
-    - name: vcpkg integrate install
-      shell: bash
-      run: |
-        cd vcpkg && ./vcpkg.exe integrate install
-
     - name: Setup
       shell: cmd
       run: |
@@ -141,6 +136,7 @@ jobs:
     - name: Test
       shell: cmd
       run: |
+        set PATH=D:\a\sxplayer\sxplayer\vcpkg\installed\x64-windows\bin;%PATH%
         "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 && ^
         meson test -C builddir
 
@@ -177,11 +173,6 @@ jobs:
         vcpkgArguments: ffmpeg[ffmpeg]
         cleanAfterBuild: false
 
-    - name: vcpkg integrate install
-      shell: bash
-      run: |
-        cd vcpkg && ./vcpkg.exe integrate install
-
     - name: Setup
       shell: cmd
       run: |
@@ -198,6 +189,7 @@ jobs:
     - name: Test
       shell: cmd
       run: |
+        set PATH=D:\a\sxplayer\sxplayer\vcpkg\installed\x64-windows\bin;%PATH%
         "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 && ^
         meson test -C builddir
 

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -115,7 +115,7 @@ jobs:
     - name: Install dependencies via vcpkg
       uses: lukka/run-vcpkg@v6
       with:
-        vcpkgGitCommitId: 595777db2332a3442b73f9af9f656355f207aec9
+        vcpkgGitCommitId: e2e6dbdaa45c40fe2e3ec7753b40d92d1dcab16e
         vcpkgTriplet: x64-windows
         vcpkgArguments: ffmpeg[ffmpeg]
         cleanAfterBuild: false
@@ -172,7 +172,7 @@ jobs:
     - name: Install dependencies via vcpkg
       uses: lukka/run-vcpkg@v6
       with:
-        vcpkgGitCommitId: 595777db2332a3442b73f9af9f656355f207aec9
+        vcpkgGitCommitId: e2e6dbdaa45c40fe2e3ec7753b40d92d1dcab16e
         vcpkgTriplet: x64-windows
         vcpkgArguments: ffmpeg[ffmpeg]
         cleanAfterBuild: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Remove pthread dependency on Windows
 
 ## [9.7.0] - 2020-12-10
 ### Added

--- a/src/async.c
+++ b/src/async.c
@@ -18,7 +18,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <pthread.h>
 
 #include <libavcodec/avcodec.h>
 #include <libavutil/avassert.h>
@@ -31,6 +30,7 @@
 #include "internal.h"
 #include "async.h"
 #include "log.h"
+#include "pthread_compat.h"
 
 #include "mod_demuxing.h"
 #include "mod_decoding.h"

--- a/src/decoder_vt.c
+++ b/src/decoder_vt.c
@@ -19,7 +19,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <pthread.h>
 #include <libavutil/avassert.h>
 #include <libavutil/pixdesc.h>
 #include <libavutil/pixfmt.h>
@@ -29,6 +28,7 @@
 #include "decoders.h"
 #include "internal.h"
 #include "log.h"
+#include "pthread_compat.h"
 
 #define BUFCOUNT_DEBUG 0
 

--- a/src/log.c
+++ b/src/log.c
@@ -18,11 +18,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#include <pthread.h>
 #include <stdarg.h>
 #include <libavutil/time.h>
 
 #include "log.h"
+#include "pthread_compat.h"
 
 struct log_ctx {
     int64_t last_time;

--- a/src/pthread_compat.h
+++ b/src/pthread_compat.h
@@ -1,0 +1,178 @@
+/*
+ * This file is part of sxplayer.
+ *
+ * Copyright (c) 2021 GoPro
+ *
+ * sxplayer is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * sxplayer is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with sxplayer; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef PTHREAD_COMPAT_H
+#define PTHREAD_COMPAT_H
+
+#ifndef _WIN32
+#include <pthread.h>
+#else
+// https://docs.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers#faster-builds-with-smaller-header-files
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <process.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdint.h>
+#include <string.h>
+
+typedef struct pthread_t {
+    void *(*func)(void *arg);
+    void *arg;
+    HANDLE handle;
+    void *ret;
+} pthread_t;
+
+typedef struct pthread_attr_t {
+    size_t stack_size;
+} pthread_attr_t;
+
+typedef SRWLOCK pthread_mutex_t;
+#define PTHREAD_MUTEX_INITIALIZER SRWLOCK_INIT
+
+typedef CONDITION_VARIABLE pthread_cond_t;
+#define PTHREAD_COND_INITIALIZER CONDITION_VARIABLE_INIT
+
+static unsigned __stdcall pthread_compat_worker(void *arg)
+{
+    pthread_t *thread = (pthread_t *)arg;
+    thread->ret = thread->func(thread->arg);
+    return 0;
+}
+
+static int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine)(void *), void *arg)
+{
+    size_t stack_size = attr ? attr->stack_size : 0;
+    memset(thread, 0, sizeof(*thread));
+    thread->func      = start_routine;
+    thread->arg       = arg;
+    /*
+     * A thread in an executable that calls the C run-time library (CRT) should
+     * use the _beginthreadex and _endthreadex functions for thread management
+     * rather than CreateThread and ExitThread; this requires the use of the
+     * multithreaded version of the CRT. If a thread created using CreateThread
+     * calls the CRT, the CRT may terminate the process in low-memory
+     * conditions.
+     * See: https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-createthread#remarks
+     */
+    thread->handle    = (HANDLE)_beginthreadex(NULL, stack_size, pthread_compat_worker, thread, 0, NULL);
+    if (!thread->handle)
+        return EAGAIN;
+    return 0;
+}
+
+static int pthread_join(pthread_t thread, void **retval)
+{
+    DWORD ret = WaitForSingleObject(thread.handle, INFINITE);
+    if (ret != WAIT_OBJECT_0)
+        return EDEADLK;
+    CloseHandle(thread.handle);
+    if (retval)
+        *retval = thread.ret;
+    return 0;
+}
+
+static int pthread_attr_init(pthread_attr_t *attr)
+{
+    memset(attr, 0, sizeof(*attr));
+    return 0;
+}
+
+static int pthread_attr_getstacksize(const pthread_attr_t *attr, size_t *size)
+{
+    *size = attr->stack_size;
+    return 0;
+}
+
+static int pthread_attr_setstacksize(pthread_attr_t *attr, size_t size)
+{
+    attr->stack_size = size;
+    return 0;
+}
+
+static int pthread_attr_destroy(pthread_attr_t *attr)
+{
+    memset(attr, 0, sizeof(*attr));
+    return 0;
+}
+
+static int pthread_mutex_init(pthread_mutex_t *mutex, void *attr)
+{
+    InitializeSRWLock(mutex);
+    return 0;
+}
+
+static int pthread_mutex_lock(pthread_mutex_t *mutex)
+{
+    AcquireSRWLockExclusive(mutex);
+    return 0;
+}
+
+static int pthread_mutex_unlock(pthread_mutex_t *mutex)
+{
+    ReleaseSRWLockExclusive(mutex);
+    return 0;
+}
+
+/*
+ * Reference: https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-initializesrwlock#remarks
+ * An unlocked SRW lock with no waiting threads is in its initial state and can
+ * be copied, moved, and forgotten without being explicitly destroyed.
+ */
+static int pthread_mutex_destroy(pthread_mutex_t *mutex)
+{
+    return 0;
+}
+
+static int pthread_cond_init(pthread_cond_t *cond, const void *attr)
+{
+    InitializeConditionVariable(cond);
+    return 0;
+}
+
+static int pthread_cond_broadcast(pthread_cond_t *cond)
+{
+    WakeAllConditionVariable(cond);
+    return 0;
+}
+
+static int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex)
+{
+    SleepConditionVariableSRW(cond, mutex, INFINITE, 0);
+    return 0;
+}
+
+static int pthread_cond_signal(pthread_cond_t *cond)
+{
+    WakeConditionVariable(cond);
+    return 0;
+}
+
+/*
+ * Reference: https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-initializeconditionvariable
+ * A condition variable with no waiting threads is in its initial state and can
+ * be copied, moved, and forgotten without being explicitly destroyed.
+ */
+static int pthread_cond_destroy(pthread_cond_t *cond)
+{
+    return 0;
+}
+#endif
+#endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -19,10 +19,10 @@
  */
 
 #define _GNU_SOURCE // pthread_setname_np on Linux
-#include <pthread.h>
 
 #include "sxplayer.h"
 #include "internal.h"
+#include "pthread_compat.h"
 
 static const struct {
     enum AVPixelFormat ff;


### PR DESCRIPTION
The pthread compatibility header implements a subset of the pthread API
on top of the Win32 thread API and removes the need of relying on the
pthread library on Windows.