### PR TITLE
async: do not log an error on lazy image seeking

### DIFF
--- a/src/async.c
+++ b/src/async.c
@@ -553,7 +553,7 @@ static int op_seek(struct async_context *actx, struct message *seek_msg)
     }
 
     if (!is_seek_possible(actx)) {
-        LOG(actx, ERROR, "can not seek into media, ignoring seek");
+        TRACE(actx, "can not seek into media, ignoring seek");
         sxpi_msg_free_data(seek_msg);
         return 0;
     }


### PR DESCRIPTION
This error logging was introduced in fc564594 to make it consistent with
the case where a skip option was explicitely specified to a media image.

The log message removed in this commit is the 2nd scenario: it happens
by side effect when doing a sxplayer_get_frame() at t≠0. For API users
(typically node.gl with a TimeRange above a Media node) this is a legit
use case because the time progresses without ever considering the type
of media below. We consider here that it's sxplayer responsiblity to
transparently handles images.