### PR TITLE
ci: add android target workflow (x86_64/arm/aarch64)

### DIFF
--- a/.github/meson-android-aarch64.ini
+++ b/.github/meson-android-aarch64.ini
@@ -1,0 +1,10 @@
+[binaries]
+c = '/usr/local/lib/android/sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android28-clang'
+strip = '/usr/local/lib/android/sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-strip'
+pkgconfig = '/usr/bin/pkg-config'
+
+[host_machine]
+system = 'android'
+cpu_family = 'arm'
+cpu = 'aarch64'
+endian = 'little'

--- a/.github/meson-android-arm.ini
+++ b/.github/meson-android-arm.ini
@@ -1,0 +1,10 @@
+[binaries]
+c = '/usr/local/lib/android/sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi28-clang'
+strip = '/usr/local/lib/android/sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/arm-linux-androideabi-strip'
+pkgconfig = '/usr/bin/pkg-config'
+
+[host_machine]
+system = 'android'
+cpu_family = 'arm'
+cpu = 'arm'
+endian = 'little'

--- a/.github/meson-android-x86_64.ini
+++ b/.github/meson-android-x86_64.ini
@@ -1,0 +1,10 @@
+[binaries]
+c = '/usr/local/lib/android/sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android28-clang'
+strip = '/usr/local/lib/android/sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android-strip'
+pkgconfig = '/usr/bin/pkg-config'
+
+[host_machine]
+system = 'android'
+cpu_family = 'x86'
+cpu = 'x86_64'
+endian = 'little'

--- a/.github/workflows/ci_android.yml
+++ b/.github/workflows/ci_android.yml
@@ -1,0 +1,66 @@
+name: 'build Android 🤖'
+
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+
+jobs:
+  android-build:
+
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86_64, arm, aarch64]
+        ffmpeg_version: ["4.4"]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        sudo apt -y update
+        sudo apt -y install meson ninja-build nasm
+
+    - name: Get ffmpeg source code
+      run: |
+        wget https://ffmpeg.org/releases/ffmpeg-${{ matrix.ffmpeg_version }}.tar.xz
+        tar -xf ffmpeg-${{ matrix.ffmpeg_version }}.tar.xz
+
+    - name: Compile ffmpeg source with the ndk toolchain for Android & install it to a specific directory
+      run: |
+        cd ffmpeg-${{ matrix.ffmpeg_version }}
+        android_suffix="android"
+        compiler=${{ matrix.arch }}
+
+        if [ ${{ matrix.arch }} == "arm" ]; then
+          android_suffix="androideabi"
+          compiler="armv7a"
+        fi
+
+        NDK_BIN_PATH=/usr/local/lib/android/sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin
+        ./configure \
+        --disable-everything --disable-doc --disable-static --disable-autodetect --disable-programs \
+        --enable-shared --enable-cross-compile --enable-jni --enable-mediacodec --enable-hwaccels  \
+        --enable-avdevice --enable-swresample --enable-rdft \
+        --arch=${{ matrix.arch }} --target-os=android \
+        --cross-prefix=$NDK_BIN_PATH/${{ matrix.arch }}-linux-${android_suffix}- \
+        --cc=$NDK_BIN_PATH/${compiler}-linux-${android_suffix}28-clang \
+        --prefix=$HOME/ffmpeg-install-${{ matrix.arch }}
+
+        make install -j$(($(nproc)+1))
+
+    - name: Build sxplayer lib for Android
+      run: |
+        PKG_CONFIG_LIBDIR=$HOME/ffmpeg-install-${{ matrix.arch }}/lib/pkgconfig/ \
+        meson setup --cross-file .github/meson-android-${{ matrix.arch }}.ini builddir
+        meson test -C builddir -v
+
+    - name: Upload Logs
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: android-logs
+        path: builddir/meson-logs

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![tests Linux](https://github.com/stupeflix/sxplayer/workflows/tests%20Linux/badge.svg)
 ![tests Mac](https://github.com/stupeflix/sxplayer/workflows/tests%20Mac/badge.svg)
 ![tests Windows](https://github.com/stupeflix/sxplayer/workflows/tests%20Windows/badge.svg)
+![build Android 🤖](https://github.com/stupeflix/sxplayer/workflows/build%20Android%20🤖/badge.svg)
 
 ## Introduction
 


### PR DESCRIPTION
This PR allows to:
-  Compile **ffmpeg** sources for different Android host,
-  Build **sxplayer** lib for each target.

One cross compilation file _(.ini)_ per architecture (_i.e_ processor type on the phone) is given as **meson** input.

Architectures are:
- **x86_64**: x86 processor 64-bit,
- **arm**: arm processor 32-bit,
- **aarch64**: arm processor 64-bit.

 A compiler for each architecture is directly provided from the  **Android ndk toolchain** on remote machine.


Notes:

- **enable-zlib:**
  - Adding  `--enable-zlib` as  _configure_ option makes _aarch64_ build fails with error: `warning: libz.so, needed by libavformat.so, not found (try using -rpath or -rpath-link)` 
  - Removing the option seems ok for every target.