### PR TITLE
log: use __func__ instead of __FUNCTION__

### DIFF
--- a/src/log.h
+++ b/src/log.h
@@ -40,7 +40,7 @@
 #endif
 
 #define DO_LOG(c, log_level, ...) sxpi_log_print((c)->log_ctx, log_level, \
-                                                 __FILE__, __LINE__, __FUNCTION__, __VA_ARGS__)
+                                                 __FILE__, __LINE__, __func__, __VA_ARGS__)
 
 #define LOG(c, level, ...) DO_LOG(c, SXPLAYER_LOG_##level, __VA_ARGS__)
 


### PR DESCRIPTION
`__func__` is part of C99 standard, `__FUNCTION__` is a compiler extension.