### PR TITLE
ci: add ios target workflow (x86_64, arm64)

### DIFF
--- a/.github/meson-ios-arm64.ini
+++ b/.github/meson-ios-arm64.ini
@@ -1,0 +1,17 @@
+[host_machine]
+system = 'darwin'
+cpu_family = 'arm'
+cpu = 'arm64'
+endian = 'little'
+
+[built-in options]
+c_args = ['-arch', 'arm64', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk']
+c_link_args = ['-arch', 'arm64', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk']
+
+[properties]
+root = '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer'
+
+[binaries]
+c = 'clang'
+strip = 'strip'
+pkgconfig = '/usr/local/bin/pkg-config'

--- a/.github/meson-ios-x86_64.ini
+++ b/.github/meson-ios-x86_64.ini
@@ -1,0 +1,17 @@
+[host_machine]
+system = 'darwin'
+cpu_family = 'x86_64'
+cpu = 'x86_64'
+endian = 'little'
+
+[built-in options]
+c_args = ['-arch', 'x86_64', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk']
+c_link_args = ['-arch', 'x86_64', '-isysroot', '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk']
+
+[properties]
+root = '/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer'
+
+[binaries]
+c = 'clang'
+strip = 'strip'
+pkgconfig = '/usr/local/bin/pkg-config'

--- a/.github/workflows/ci_ios.yml
+++ b/.github/workflows/ci_ios.yml
@@ -1,0 +1,81 @@
+name: 'build iOS 🍏'
+
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+
+jobs:
+  ios-build:
+
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x86_64, arm64]
+        ffmpeg_version: ["4.4"]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        brew install meson nasm jq pkg-config
+
+    - name: Get ffmpeg source code
+      run: |
+        wget https://ffmpeg.org/releases/ffmpeg-${{ matrix.ffmpeg_version }}.tar.xz
+        tar -xf ffmpeg-${{ matrix.ffmpeg_version }}.tar.xz
+
+    - name: Compile ffmpeg source with the Xcode toolchain for ios & install it to a specific directory
+      run: |
+        if [ ${{ matrix.arch }} == "x86_64" ]; then
+          PLATFORM="iphonesimulator"
+          IOS_VERSION=$(xcrun simctl list runtimes iOS -j|jq '.runtimes|last.version')
+          CFLAGS="-arch ${{ matrix.arch }} -mios-simulator-version-min=$IOS_VERSION"
+        elif [ ${{ matrix.arch }} == "arm64" ]; then
+          PLATFORM="iphoneos"
+          IOS_VERSION=$(xcrun --sdk $PLATFORM --show-sdk-version)
+          CFLAGS="-arch ${{ matrix.arch }} -mios-version-min=$IOS_VERSION"
+        else
+          echo "Unknown architecture ${{ matrix.arch }}"
+          exit 1
+        fi
+
+        SDK=$(xcrun --sdk $PLATFORM --show-sdk-path)
+        LDFLAGS="$CFLAGS"
+
+        cd ffmpeg-${{ matrix.ffmpeg_version }}
+
+        ./configure \
+        --disable-everything --disable-doc --disable-static --disable-autodetect --disable-programs \
+        --enable-shared --enable-cross-compile \
+        --enable-avdevice --enable-swresample --enable-rdft \
+        --enable-filter=aresample,aformat,asetnsamples,asettb,copy,format,scale,settb \
+        --enable-demuxer=image_jpeg_pipe,matroska \
+        --enable-decoder=mjpeg,flac,h264 \
+        --enable-parser=h264,mjpeg,flac \
+        --enable-protocol=file \
+        --target-os=darwin \
+        --arch=${{ matrix.arch }} \
+        --sysroot=$SDK \
+        --extra-cflags="$CFLAGS" \
+        --extra-ldflags="$LDFLAGS" \
+        --prefix=$HOME/ffmpeg-install-${{ matrix.ffmpeg_version }}
+
+        make install -j $(sysctl -n hw.ncpu)
+
+    - name: Build sxplayer lib for ios
+      run: |
+        PKG_CONFIG_LIBDIR=$HOME/ffmpeg-install-${{ matrix.ffmpeg_version }}/lib/pkgconfig \
+        LDFLAGS="$LDFLAGS -L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/" \
+        meson setup --cross-file .github/meson-ios-${{ matrix.arch }}.ini builddir
+        meson compile -C builddir -v
+
+    - name: Upload Logs
+      if: always()
+      uses: actions/upload-artifact@v2
+      with:
+        name: ios-shared-logs
+        path: builddir/meson-logs

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![tests Mac](https://github.com/stupeflix/sxplayer/workflows/tests%20Mac/badge.svg)
 ![tests Windows](https://github.com/stupeflix/sxplayer/workflows/tests%20Windows/badge.svg)
 ![build Android 🤖](https://github.com/stupeflix/sxplayer/workflows/build%20Android%20🤖/badge.svg)
+![build iOS 🍏](https://github.com/stupeflix/sxplayer/workflows/build%20iOS%20🍏/badge.svg)
 
 ## Introduction
 


### PR DESCRIPTION
### Description:

This PR allows to:
- Compile **ffmpeg** sources for different ios host,
- Build **sxplayer** lib for each target.

Target architectures are:

- **x86_64**: x86 processor 64-bit (ios **simulator**),
- **aarch64**: arm processor 64-bit (**iphone** device).

As in android CI, I introduce **.ini** cross-compilation files with instructions for meson.
 
A **badge** inside README as been also added.

I mainly used **xcrun**  native ios tool (with **jq** to parse json output) to automatically:
- find the right **compilators**:
`/Applications/Xcode_12.4.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang`
- find the right **SDKs**: 
    - x86_64:  `/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator14.4.sdk`
    - arm64:
`/Applications/Xcode_12.4.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.4.sdk`
- find the right minimum ios **version**:  `14.4`
 

Note that for arm64 architecture, the ` [built-in options]` part is mandatory, if not present, clang will compile libsxplayer for `x86_64` so the link with ffmpeg compiled in ios-arm64 fails.

### Needed variables for meson dependencies:

Some variables have to be defined to solve run-time dependencies not done automatically.
  
- **PKG_CONFIG_LIBDIR**: 
       - as in Android CI, needed to specify where to search generated `.pc` ffmpeg compiled files for x86_64 or amr64 target.

- **LDFLAGS**:
##### 1/ Some standard headers like `<errno.h>` are not found.
 -  Error: ` /Users/runner/ffmpeg-install/include/libavcodec/avcodec.h:30:10: fatal error: 'errno.h' file not found`.
- Location: `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/sys/errno.h`
##### 2/ `System` library is also not found by default.
- Error:   `ld: library not found for -lSystem`.
- Location: `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System`
##### 3/ Some Apple standard **frameworks** (Corefoundation CoreMedia CoreVideo QuartzCore VideoToolbox) are not found also by default.
 - Error: `ld: framework not found Corefoundation`.
- Location: `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/CoreFoundation.framework`
  
Needed libraries and frameworks are located under the SDK and not in standard `/usr/include` directory.  
So I added the directory containing necessary frameworks and libs in LDFLAGS:
         `-L/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/`



### Side notes:
- Github action provide a range of **Xcode** versions:
     - Here the list: `10.3.0, 11.2.1, 11.3.1, 11.4.1, 11.5.0, 11.6.0, 11.7.0, 12.0.1, 12.1.1, 12.2.0, 12.3.0, 12.4.0`
     - Let me know if you think it's relevant to use different chosen versions in a matrix.
     - Xcode per default here is 12.4.0 (`xcodebuild -version`)
- Doc: https://developer.apple.com/fr/support/xcode/ to see compatibility between OS & SDKS.
  