### PR TITLE
ci_win: pkg-config from Chocolatey instead pkg-config from Strawberry

### DIFF
--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -109,10 +109,11 @@ jobs:
         python-version: '3.x'
         architecture: 'x64'
 
-    - name: Install meson
+    - name: Install meson and pkg-config
       shell: bash
       run: |
         pip install meson
+        choco install pkgconfiglite
 
     - name: Install dependencies via vcpkg
       uses: lukka/run-vcpkg@v6
@@ -162,10 +163,11 @@ jobs:
         python-version: '3.x'
         architecture: 'x64'
 
-    - name: Install meson
+    - name: Install meson and pkg-config
       shell: bash
       run: |
         pip install meson
+        choco install pkgconfiglite
 
     - name: Install dependencies via vcpkg
       uses: lukka/run-vcpkg@v6


### PR DESCRIPTION
Meson blacklisted the detection of the broken wrapper
Strawberry\perl\bin\pkg-config.BAT starting meson 0.60. This causes the
pkg-config detection to start failing on our Windows CI because it is the only
pkg-config implementation available on the base system. In order to pull a
proper implementation of pkg-config, we use the Chocolatey package manager.