### PR TITLE
ci: use compile instead test in meson

### DIFF
--- a/.github/workflows/ci_android.yml
+++ b/.github/workflows/ci_android.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         PKG_CONFIG_LIBDIR=$HOME/ffmpeg-install-${{ matrix.arch }}/lib/pkgconfig/ \
         meson setup --cross-file .github/meson-android-${{ matrix.arch }}.ini builddir
-        meson test -C builddir -v
+        meson compile -C builddir -v
 
     - name: Upload Logs
       if: ${{ always() }}


### PR DESCRIPTION
For the moment, meson skips tests since we need to invoke a simulator to be able to run tests.
So using "compile" meson command instead "test" is enough and more explicit.
