### PR TITLE
decoder_vt: fix preferred format list for 8-bit formats

### DIFF
--- a/src/decoder_vt.c
+++ b/src/decoder_vt.c
@@ -376,9 +376,9 @@ static enum AVPixelFormat select_pix_fmt(const enum AVPixelFormat *pix_fmts,
                                          enum AVPixelFormat in_pix_fmt)
 {
     static const enum AVPixelFormat preferred_pix_fmts_8[] = {
-        AV_PIX_FMT_P010,
-        AV_PIX_FMT_BGRA,
         AV_PIX_FMT_NV12,
+        AV_PIX_FMT_BGRA,
+        AV_PIX_FMT_P010,
         AV_PIX_FMT_NONE
     };
     static const enum AVPixelFormat preferred_pix_fmts_10[] = {


### PR DESCRIPTION
Prefers NV12 and BGRA over P010 for 8-bit formats.