### PR TITLE
player: rewrite player using SDL2

### DIFF
--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         sudo apt -y update
         sudo apt -y install meson ninja-build
-        sudo apt -y install libglfw3-dev libglew-dev
+        sudo apt -y install libsdl2-dev
         sudo apt -y install libavcodec-dev libavutil-dev libavformat-dev libavdevice-dev libavfilter-dev libswscale-dev libswresample-dev libpostproc-dev
 
     - name: Run tests
@@ -44,7 +44,7 @@ jobs:
       run: |
         sudo apt -y update
         sudo apt -y install meson ninja-build
-        sudo apt -y install libglfw3-dev libglew-dev
+        sudo apt -y install libsdl2-dev
         sudo apt -y install libavcodec-dev libavutil-dev libavformat-dev libavdevice-dev libavfilter-dev libswscale-dev libswresample-dev libpostproc-dev
 
     - name: Run tests
@@ -70,7 +70,7 @@ jobs:
       run: |
         sudo apt -y update
         sudo apt -y install meson ninja-build
-        sudo apt -y install libglfw3-dev libglew-dev
+        sudo apt -y install libsdl2-dev
         sudo apt -y install libavcodec-dev libavutil-dev libavformat-dev libavdevice-dev libavfilter-dev libswscale-dev libswresample-dev libpostproc-dev
         sudo apt -y install valgrind
 

--- a/.github/workflows/ci_mac.yml
+++ b/.github/workflows/ci_mac.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         brew install meson ninja
-        brew install glfw3 glew
+        brew install sdl2
         brew install ffmpeg
         brew install pkg-config
 
@@ -43,7 +43,7 @@ jobs:
     - name: Install dependencies
       run: |
         brew install meson ninja
-        brew install glfw3 glew
+        brew install sdl2
         brew install ffmpeg
         brew install pkg-config
 

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Setup
         run: |
-          meson setup builddir --default-library static
+          meson setup builddir --default-library static -Dplayer=disabled
 
       - name: Build
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Player has been ported from GLEW/GLFW3 to SDL2
 
 ## [9.10.0] - 2021-10-18
 ### Added

--- a/meson.build
+++ b/meson.build
@@ -143,12 +143,8 @@ pkg.generate(
 #
 
 player_deps = lib_deps + [
-  dependency('glfw3', required: get_option('player')),
-  dependency('glew', required: get_option('player')),
+  dependency('sdl2', required: get_option('player')),
 ]
-if host_system == 'darwin'
-  player_deps += dependency('appleframeworks', modules: ['OpenGL'], required: get_option('player'))
-endif
 player_deps_found = true
 foreach dep : player_deps
   player_deps_found = player_deps_found and dep.found()

--- a/src/sxplayer.c
+++ b/src/sxplayer.c
@@ -185,6 +185,14 @@ static int key_callback(struct player *p, SDL_KeyboardEvent *event)
     case SDLK_RIGHT:
         update_time(p, clipi64(p->frame_ts + 10 * 1000000, 0, p->duration));
         break;
+    case SDLK_o:
+        p->paused = 1;
+        set_frame_index(p, clipi64(p->frame_index - 1, 0, p->duration_i));
+        break;
+    case SDLK_p:
+        p->paused = 1;
+        set_frame_index(p, clipi64(p->frame_index + 1, 0, p->duration_i));
+        break;
     case SDLK_s:
     case SDLK_PERIOD:
         p->paused = 1;

--- a/src/sxplayer.c
+++ b/src/sxplayer.c
@@ -1,374 +1,317 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <GL/glew.h>
-#include <GLFW/glfw3.h>
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <SDL.h>
 
 #include "sxplayer.h"
 
-static const char *g_vertex_shader_data =
-    "#version 330 core"                                  "\n"
-    "layout(location = 0) in vec3 pos;"                  "\n"
-    "layout(location = 1) in vec2 uv;"                   "\n"
-    "out vec2 tex_coord;"                                "\n"
-    "void main(){"                                       "\n"
-    "    gl_Position = vec4(pos, 1);"                    "\n"
-    "    tex_coord = uv;"                                "\n"
-    "}"                                                  "\n";
+struct player {
+    struct sxplayer_ctx *sxplayer_ctx;
 
-static const char *g_fragment_shader_data =
-    "#version 330 core"                                  "\n"
-    "in vec2 tex_coord;"                                 "\n"
-    "out vec3 color;"                                    "\n"
-    "uniform sampler2D tex_sampler;"                     "\n"
-    "void main() {"                                      "\n"
-    "    color = texture(tex_sampler, tex_coord).rgb;"   "\n"
-    "}"                                                  "\n";
+    SDL_Window *window;
+    SDL_Renderer *renderer;
+    SDL_Texture *texture;
+    int texture_width;
+    int texture_height;
 
-static GLuint load_shader(const char *vertex_shader, const char *fragment_shader)
-{
-    char *info_log = NULL;
-    int info_log_length = 0;
+    int framerate[2];
+    double duration_f;
+    int64_t duration;
+    int64_t duration_i;
+    int width;
+    int height;
 
-    GLint result = GL_FALSE;
+    int64_t clock_off;
+    int64_t frame_ts;
+    int64_t frame_index;
+    double  frame_time;
+    int paused;
+    int seeking;
+    int next_frame_requested;
+    int mouse_down;
+};
 
-    GLuint g_program_id = glCreateProgram();
-    GLuint vertex_shader_id = glCreateShader(GL_VERTEX_SHADER);
-    GLuint fragment_shader_id = glCreateShader(GL_FRAGMENT_SHADER);
-
-    glShaderSource(vertex_shader_id, 1, &vertex_shader, NULL);
-    glCompileShader(vertex_shader_id);
-
-    glGetShaderiv(vertex_shader_id, GL_COMPILE_STATUS, &result);
-    glGetShaderiv(vertex_shader_id, GL_INFO_LOG_LENGTH, &info_log_length);
-    if (info_log_length > 1) {
-        info_log = malloc(info_log_length + 1);
-        if (!info_log) {
-            goto error;
-        }
-        glGetShaderInfoLog(vertex_shader_id, info_log_length, NULL, info_log);
-        goto error;
-    }
-
-    glShaderSource(fragment_shader_id, 1, &fragment_shader, NULL);
-    glCompileShader(fragment_shader_id);
-
-    glGetShaderiv(fragment_shader_id, GL_COMPILE_STATUS, &result);
-    glGetShaderiv(fragment_shader_id, GL_INFO_LOG_LENGTH, &info_log_length);
-    if (info_log_length > 1) {
-        info_log = malloc(info_log_length + 1);
-        if (!info_log) {
-            goto error;
-        }
-        glGetShaderInfoLog(fragment_shader_id, info_log_length, NULL, info_log);
-        goto error;
-    }
-
-    glAttachShader(g_program_id, vertex_shader_id);
-    glAttachShader(g_program_id, fragment_shader_id);
-    glLinkProgram(g_program_id);
-
-    glGetProgramiv(g_program_id, GL_LINK_STATUS, &result);
-    glGetProgramiv(g_program_id, GL_INFO_LOG_LENGTH, &info_log_length);
-    if (info_log_length > 1) {
-        info_log = malloc(info_log_length + 1);
-        if (!info_log) {
-            goto error;
-        }
-        glGetProgramInfoLog(g_program_id, info_log_length, NULL, info_log);
-        goto error;
-    }
-
-    glDeleteShader(vertex_shader_id);
-    glDeleteShader(fragment_shader_id);
-
-    return g_program_id;
-
-error:
-    if (info_log) {
-        fprintf(stderr, "Failed to load shaders: %s\n", info_log);
-        free(info_log);
-    }
-
-    if (vertex_shader_id) {
-        glDeleteShader(vertex_shader_id);
-    }
-
-    if (fragment_shader_id) {
-        glDeleteShader(fragment_shader_id);
-    }
-
-    if (g_program_id) {
-        glDeleteProgram(g_program_id);
-    }
-
-    return 0;
-}
-
-static GLuint g_vertex_array_id;
-static GLuint g_program_id;
-static GLuint g_sampler_id;
-static GLuint g_vertex_buffer_id;
-static GLuint g_uv_buffer_id;
-static GLuint g_texture_id;
-static GLfloat g_padding;
-
-static int g_paused;
-static double g_last_rendered_frame_ts;
-static double g_subtime;
-struct sxplayer_info g_info;
-struct sxplayer_ctx *g_s;
-
-static int init(void)
-{
-    static const GLfloat vertex_buffer_data[] = {
-        1.0f, -1.0f, 0.0f,
-        -1.0f, -1.0f, 0.0f,
-        -1.0f, 1.0f, 0.0f,
-
-        1.0f, -1.0f, 0.0f,
-        -1.0f, 1.0f, 0.0f,
-        1.0f, 1.0f, 0.0f,
-    };
-    static const GLfloat uv_buffer_data[] = {
-        1.0f, 1.0f,
-        0.0f, 1.0f,
-        0.0f, 0.0f,
-
-        1.0f, 1.0f,
-        0.0f, 0.0f,
-        1.0f, 0.0f
-    };
-
-    glClearColor(0.0f, 1.0f, 0.0f, 0.0f);
-
-    g_program_id = load_shader(g_vertex_shader_data, g_fragment_shader_data);
-    g_sampler_id = glGetUniformLocation(g_program_id, "tex_sampler");
-
-    glGenVertexArrays(1, &g_vertex_array_id);
-    glBindVertexArray(g_vertex_array_id);
-
-    glGenTextures(1, &g_texture_id);
-    glBindTexture(GL_TEXTURE_2D, g_texture_id);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    glBindTexture(GL_TEXTURE_2D, 0);
-
-    glGenBuffers(1, &g_vertex_buffer_id);
-    glBindBuffer(GL_ARRAY_BUFFER, g_vertex_buffer_id);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(vertex_buffer_data), vertex_buffer_data, GL_STATIC_DRAW);
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-
-    glGenBuffers(1, &g_uv_buffer_id);
-    glBindBuffer(GL_ARRAY_BUFFER, g_uv_buffer_id);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(uv_buffer_data), uv_buffer_data, GL_STATIC_DRAW);
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-
-    glUseProgram(g_program_id);
-
-    return 0;
-}
-
-static int reset(void)
-{
-    glDeleteVertexArrays(1, &g_vertex_array_id);
-    glDeleteProgram(g_program_id);
-    glDeleteTextures(1, &g_sampler_id);
-    glDeleteBuffers(1, &g_vertex_buffer_id);
-    glDeleteBuffers(1, &g_uv_buffer_id);
-    glDeleteTextures(1, &g_texture_id);
-
-    return 0;
-}
-
-static int update_texture_padding(const float padding)
-{
-    const GLfloat uv_buffer_data[] = {
-        padding, 1.0f,
-        0.0f,    1.0f,
-        0.0f,    0.0f,
-
-        padding, 1.0f,
-        0.0f,    0.0f,
-        padding, 0.0f,
-    };
-
-    if (padding == g_padding)
-        return 0;
-
-    glGenBuffers(1, &g_uv_buffer_id);
-    glBindBuffer(GL_ARRAY_BUFFER, g_uv_buffer_id);
-    glBufferData(GL_ARRAY_BUFFER, sizeof(uv_buffer_data), uv_buffer_data, GL_STATIC_DRAW);
-    glBindBuffer(GL_ARRAY_BUFFER, 0);
-
-    g_padding = padding;
-
-    return 0;
-}
-
-static void error_callback(int error, const char *description)
-{
-    fprintf(stderr, "glfw error: %s\n", description);
-}
-
-static void render_frame(GLFWwindow *window, struct sxplayer_frame *frame)
-{
-    glClear(GL_COLOR_BUFFER_BIT);
-
-    glActiveTexture(GL_TEXTURE0);
-    glBindTexture(GL_TEXTURE_2D, g_texture_id);
-    if (frame) {
-        if (frame->width != (frame->linesize >> 2)) {
-            float padding = frame->width / (float)(frame->linesize >> 2);
-            update_texture_padding(padding);
-        }
-
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, frame->linesizep[0] >> 2, frame->height, 0, GL_RGBA,  GL_UNSIGNED_BYTE, frame->datap[0]);
-        g_last_rendered_frame_ts = frame->ts;
-    }
-    glUniform1i(g_sampler_id, 0);
-
-    glEnableVertexAttribArray(0);
-    glBindBuffer(GL_ARRAY_BUFFER, g_vertex_buffer_id);
-    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, NULL);
-
-    glEnableVertexAttribArray(1);
-    glBindBuffer(GL_ARRAY_BUFFER, g_uv_buffer_id);
-    glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 0, NULL);
-
-    glDrawArrays(GL_TRIANGLES, 0, 2 * 3);
-    glDisableVertexAttribArray(0);
-    glDisableVertexAttribArray(1);
-    glBindTexture(GL_TEXTURE_2D, 0);
-
-    glfwSwapBuffers(window);
-}
-
-static void render(GLFWwindow *window)
-{
-    const double time = glfwGetTime() - g_subtime;
-    struct sxplayer_frame *frame = sxplayer_get_frame(g_s, time);
-
-    render_frame(window, frame);
-
-    sxplayer_release_frame(frame);
-}
-
-static double clipd(double v, double min, double max)
+static int64_t clipi64(int64_t v, int64_t min, int64_t max)
 {
     if (v < min) return min;
     if (v > max) return max;
     return v;
 }
 
-static void seek_to(GLFWwindow *window, double t)
+static int64_t gettime_relative(void)
 {
-    t = clipd(t, 0, g_info.duration);
-    printf("seek to %f/%f (%d%%)\n", t, g_info.duration, (int)(t/g_info.duration*100));
-    g_subtime = glfwGetTime() - t;
-    if (g_paused)
-        render(window);
+    return SDL_GetTicks() * 1000;
 }
 
-static void mouse_button_callback(GLFWwindow* window, int button, int action, int mods)
+static void set_frame_ts(struct player *p, int64_t frame_ts)
 {
-    if (button == GLFW_MOUSE_BUTTON_LEFT && action == GLFW_PRESS) {
-        double xpos, ypos;
-        glfwGetCursorPos(window, &xpos, &ypos);
-        seek_to(window, xpos / g_info.width * g_info.duration);
+    p->frame_ts = frame_ts;
+    p->frame_index = llrint((p->frame_ts * p->framerate[0]) / (double)(p->framerate[1] * 1000000));
+    p->frame_time = (p->frame_index * p->framerate[1]) / (double)p->framerate[0];
+}
+
+static void set_frame_index(struct player *p, int64_t frame_index)
+{
+    p->frame_index = frame_index;
+    p->frame_time = (p->frame_index * p->framerate[1]) / (double)p->framerate[0];
+    p->frame_ts = llrint(p->frame_index * p->framerate[1] * 1000000 / (double)p->framerate[0]);
+}
+
+static void update_time(struct player *p, int64_t seek_at)
+{
+    if (seek_at >= 0) {
+        p->seeking = 1;
+        p->clock_off = gettime_relative() - seek_at;
+        set_frame_ts(p, seek_at);
+        printf("Seek to %f/%f (%d%%)\n", p->frame_time, p->duration_f, (int)(p->frame_time/p->duration_f*100));
+        return;
     }
-}
 
-static void key_callback(GLFWwindow* window, int key, int scancode, int action, int mods)
-{
-    if (action == GLFW_PRESS) {
-        if (key == GLFW_KEY_ESCAPE || key == GLFW_KEY_Q) {
-            glfwSetWindowShouldClose(window, GL_TRUE);
-        } else if (key == GLFW_KEY_SPACE) {
-            g_paused ^= 1;
-            if (g_paused) {
-                printf("pause\n");
-            } else {
-                printf("unpause\n");
-                g_subtime = glfwGetTime() - g_last_rendered_frame_ts;
-            }
-        } else if (key == GLFW_KEY_PERIOD || key == GLFW_KEY_S) {
-            g_paused = 1;
-            struct sxplayer_frame *frame = sxplayer_get_next_frame(g_s);
-            if (frame) {
-                printf("stepped to frame t=%f\n", frame->ts);
-                render_frame(window, frame);
-                sxplayer_release_frame(frame);
-            }
-        } else if (key == GLFW_KEY_LEFT) {
-            seek_to(window, g_last_rendered_frame_ts - 5.0);
-        } else if (key == GLFW_KEY_RIGHT) {
-            seek_to(window, g_last_rendered_frame_ts + 5.0);
+    if (!p->paused && !p->mouse_down) {
+        const int64_t now = gettime_relative();
+        if (p->clock_off == INT64_MIN || now - p->clock_off > p->duration) {
+            p->seeking = 1;
+            p->clock_off = now;
         }
+
+        set_frame_ts(p, now - p->clock_off);
     }
+}
+
+static void reset_running_time(struct player *p)
+{
+    p->clock_off = gettime_relative() - p->frame_ts;
+}
+
+static void size_callback(struct player *p, int width, int height)
+{
+    p->width = width;
+    p->height = height;
+}
+
+static void seek_event(struct player *p, int x)
+{
+    const int64_t seek_at64 = p->duration * x / p->width;
+    update_time(p, clipi64(seek_at64, 0, p->duration));
+}
+
+static void mouse_buttondown_callback(struct player *p, SDL_MouseButtonEvent *event)
+{
+    p->mouse_down = 1;
+    seek_event(p, event->x);
+}
+
+static void mouse_buttonup_callback(struct player *p, SDL_MouseButtonEvent *event)
+{
+    p->mouse_down = 0;
+    p->clock_off = gettime_relative() - p->frame_ts;
+}
+
+static void mouse_pos_callback(struct player *p, SDL_MouseMotionEvent *event)
+{
+    if (p->mouse_down)
+        seek_event(p, event->x);
+}
+
+static void render(struct player *p)
+{
+    struct sxplayer_frame *frame;
+    if (p->next_frame_requested) {
+        frame = sxplayer_get_next_frame(p->sxplayer_ctx);
+        if (frame) {
+            printf("Stepped to frame t=%f\n", frame->ts);
+            set_frame_ts(p, frame->ts * 1000000);
+        }
+        p->next_frame_requested = 0;
+    } else {
+        update_time(p, -1);
+        frame = sxplayer_get_frame(p->sxplayer_ctx, p->frame_time);
+    }
+
+    if (p->seeking) {
+        reset_running_time(p);
+        p->seeking = 0;
+    }
+
+    if (!frame) {
+        SDL_RenderClear(p->renderer);
+        if (p->texture)
+            SDL_RenderCopy(p->renderer, p->texture, NULL, NULL);
+        return;
+    }
+
+    if (!p->texture ||
+        p->texture_width != frame->width ||
+        p->texture_height != frame->height) {
+        if (p->texture)
+            SDL_DestroyTexture(p->texture);
+        p->texture = SDL_CreateTexture(p->renderer,
+                                       SDL_PIXELFORMAT_ABGR8888,
+                                       SDL_TEXTUREACCESS_STREAMING,
+                                       frame->width,
+                                       frame->height);
+        if (!p->texture) {
+            fprintf(stderr, "Failed to allocate SDL texture: %s\n", SDL_GetError());
+            sxplayer_release_frame(frame);
+            return;
+        }
+        p->texture_width = frame->width;
+        p->texture_height = frame->height;
+    }
+
+    SDL_UpdateTexture(p->texture, NULL, frame->datap[0], frame->linesize);
+    SDL_RenderClear(p->renderer);
+    SDL_RenderCopy(p->renderer, p->texture, NULL, NULL);
+
+    sxplayer_release_frame(frame);
+}
+
+static int key_callback(struct player *p, SDL_KeyboardEvent *event)
+{
+    const SDL_Keycode key = event->keysym.sym;
+    switch (key) {
+    case SDLK_ESCAPE:
+    case SDLK_q:
+        return 1;
+    case SDLK_SPACE:
+        p->paused ^= 1;
+        reset_running_time(p);
+        break;
+    case SDLK_LEFT:
+        update_time(p, clipi64(p->frame_ts - 5 * 1000000, 0, p->duration));
+        break;
+    case SDLK_RIGHT:
+        update_time(p, clipi64(p->frame_ts + 5 * 1000000, 0, p->duration));
+        break;
+    case SDLK_s:
+    case SDLK_PERIOD:
+        p->paused = 1;
+        p->next_frame_requested = 1;
+        break;
+    default:
+        break;
+    }
+
+    return 0;
+}
+
+static void print_usage(const char *name)
+{
+    fprintf(stderr, "Usage: %s <media> [-framerate 60/1]\n", name);
 }
 
 int main(int ac, char **av)
 {
-    int ret;
-    GLFWwindow *window;
+    int ret = 0;
+    int framerate[2] = {60, 1};
 
-    if (ac != 2) {
-        fprintf(stderr, "Usage: %s <media>\n", av[0]);
+    if (ac != 2 && ac != 4) {
+        print_usage(av[0]);
         return -1;
     }
 
-    g_s = sxplayer_create(av[1]);
-    if (!g_s)
-        return -1;
-
-    sxplayer_set_option(g_s, "sw_pix_fmt", SXPLAYER_PIXFMT_RGBA);
-    sxplayer_set_option(g_s, "auto_hwaccel", 0);
-
-    ret = sxplayer_get_info(g_s, &g_info);
-    if (ret < 0)
-        return ret;
-
-    if (!glfwInit())
-        return -1;
-
-    glfwSetErrorCallback(error_callback);
-
-    glfwWindowHint(GLFW_SAMPLES, 0);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
-    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
-    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-
-    window = glfwCreateWindow(g_info.width, g_info.height, "sxplayer", NULL, NULL);
-    if (!window) {
-        glfwTerminate();
-        return -1;
+    if (ac == 4) {
+        if (strcmp(av[2], "-framerate") || sscanf(av[3], "%d/%d", &framerate[0], &framerate[1]) != 2) {
+            print_usage(av[0]);
+            return -1;
+        }
     }
 
-    glfwMakeContextCurrent(window);
-
-    glewExperimental = 1;
-    if (glewInit() != GLEW_OK) {
-        fprintf(stderr, "Failed to initialize GLEW\n");
-        return -1;
+    struct player p = {
+        .sxplayer_ctx = sxplayer_create(av[1]),
+    };
+    if (!p.sxplayer_ctx) {
+        ret = -1;
+        goto done;
     }
 
-    glfwSwapInterval(1);
-    glfwSetKeyCallback(window, key_callback);
-    glfwSetMouseButtonCallback(window, mouse_button_callback);
+    sxplayer_set_option(p.sxplayer_ctx, "sw_pix_fmt", SXPLAYER_PIXFMT_RGBA);
+    sxplayer_set_option(p.sxplayer_ctx, "auto_hwaccel", 0);
 
-    init();
-    while (!glfwWindowShouldClose(window)) {
-        if (!g_paused)
-            render(window);
-        glfwPollEvents();
+    struct sxplayer_info info = {0};
+    ret = sxplayer_get_info(p.sxplayer_ctx, &info);
+    if (ret < 0) {
+        ret = -1;
+        goto done;
     }
-    reset();
 
-    sxplayer_free(&g_s);
-    glfwDestroyWindow(window);
-    glfwTerminate();
-    return 0;
+    p.framerate[0]    = framerate[0];
+    p.framerate[1]    = framerate[1];
+    p.duration_f      = info.duration;
+    p.duration        = p.duration_f * 1000000;
+    p.duration_i      = llrint(p.duration_f * p.framerate[0] / (double)p.framerate[1]);
+    p.width           = info.width;
+    p.height          = info.height;
+    p.clock_off       = INT64_MIN;
+
+#ifdef SDL_MAIN_HANDLED
+    SDL_SetMainReady();
+#endif
+    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+        fprintf(stderr, "Failed to initialize SDL: %s\n", SDL_GetError());
+        ret = -1;
+        goto done;
+    }
+
+    char title[256];
+    snprintf(title, sizeof(title), "sxplayer - %s", av[1]);
+    p.window = SDL_CreateWindow(title,
+                                SDL_WINDOWPOS_UNDEFINED,
+                                SDL_WINDOWPOS_UNDEFINED,
+                                p.width,
+                                p.height,
+                                SDL_WINDOW_RESIZABLE);
+    if (!p.window) {
+        fprintf(stderr, "Failed to create SDL window: %s\n", SDL_GetError());
+        ret = -1;
+        goto done;
+    }
+
+    p.renderer = SDL_CreateRenderer(p.window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
+    if (!p.renderer) {
+        fprintf(stderr, "Failed to create SDL renderer: %s\n", SDL_GetError());
+        ret = -1;
+        goto done;
+    }
+    SDL_SetRenderDrawColor(p.renderer, 0, 0, 0, 255);
+
+    int run = 1;
+    while (run) {
+        render(&p);
+        SDL_RenderPresent(p.renderer);
+        SDL_Event event;
+        while (SDL_PollEvent(&event)) {
+            switch (event.type) {
+            case SDL_WINDOWEVENT:
+                if (event.window.event == SDL_WINDOWEVENT_CLOSE)
+                    run = 0;
+                else if (event.window.event == SDL_WINDOWEVENT_SIZE_CHANGED)
+                    size_callback(&p, event.window.data1, event.window.data2);
+                break;
+            case SDL_KEYDOWN:
+                run = key_callback(&p, &event.key) == 0;
+                break;
+            case SDL_MOUSEBUTTONDOWN:
+                mouse_buttondown_callback(&p, &event.button);
+                break;
+            case SDL_MOUSEBUTTONUP:
+                mouse_buttonup_callback(&p, &event.button);
+                break;
+            case SDL_MOUSEMOTION:
+                mouse_pos_callback(&p, &event.motion);
+                break;
+            }
+        }
+    }
+
+done:
+    SDL_DestroyTexture(p.texture);
+    SDL_DestroyRenderer(p.renderer);
+    SDL_DestroyWindow(p.window);
+    SDL_Quit();
+    sxplayer_free(&p.sxplayer_ctx);
+
+    return ret;
 }

--- a/src/sxplayer.c
+++ b/src/sxplayer.c
@@ -31,6 +31,7 @@ struct player {
     int seeking;
     int next_frame_requested;
     int mouse_down;
+    int fullscreen;
 };
 
 static int64_t clipi64(int64_t v, int64_t min, int64_t max)
@@ -178,6 +179,10 @@ static int key_callback(struct player *p, SDL_KeyboardEvent *event)
     case SDLK_SPACE:
         p->paused ^= 1;
         reset_running_time(p);
+        break;
+    case SDLK_f:
+        p->fullscreen ^= 1;
+        SDL_SetWindowFullscreen(p->window, p->fullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
         break;
     case SDLK_LEFT:
         update_time(p, clipi64(p->frame_ts - 10 * 1000000, 0, p->duration));

--- a/src/sxplayer.c
+++ b/src/sxplayer.c
@@ -180,10 +180,10 @@ static int key_callback(struct player *p, SDL_KeyboardEvent *event)
         reset_running_time(p);
         break;
     case SDLK_LEFT:
-        update_time(p, clipi64(p->frame_ts - 5 * 1000000, 0, p->duration));
+        update_time(p, clipi64(p->frame_ts - 10 * 1000000, 0, p->duration));
         break;
     case SDLK_RIGHT:
-        update_time(p, clipi64(p->frame_ts + 5 * 1000000, 0, p->duration));
+        update_time(p, clipi64(p->frame_ts + 10 * 1000000, 0, p->duration));
         break;
     case SDLK_s:
     case SDLK_PERIOD:


### PR DESCRIPTION
This rewrite removes the dependency over glfw and glew in favor of SDL2.
While it simplifies the code, it brings the following improvements:
- fullscreen mode is now supported (using the 'f' key)
- stepping backward is now supported (using the 'o' key)
- stepping foward now uses the 'p' keys
- the video aspect ratio is maintained