### PR TITLE
player: do use set_frame_ts() after stepping foward using sxplayer_ge…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Player has been ported from GLEW/GLFW3 to SDL2
 
+### Fixed
+- Fix VideoToolbox automatic 8-bit pixel format selection
+
 ## [9.10.0] - 2021-10-18
 ### Added
 - Add VideoToolbox automatic pixel format selection and P010 support

--- a/src/sxplayer.c
+++ b/src/sxplayer.c
@@ -154,7 +154,9 @@ static void render(struct player *p)
         frame = sxplayer_get_next_frame(p->sxplayer_ctx);
         if (frame) {
             printf("Stepped to frame t=%f\n", frame->ts);
-            set_frame_ts(p, frame->ts * 1000000);
+            p->frame_ts = frame->ts * 1000000;
+            p->frame_index = llrint((p->frame_ts * p->framerate[0]) / (double)(p->framerate[1] * 1000000));
+            p->frame_time = frame->ts;
         }
         p->next_frame_requested = 0;
     } else {


### PR DESCRIPTION
…t_next_frame()

The specified framerate (which defaults to 60/1) might not be aligned
with the actual frame timestamps, thus, we cannot use set_frame_ts()
after stepping forward using sxplayer_get_next_frame() to set the
current timings information because set_frame_ts() aligns
player.frame_time to the specified framerate. Instead we set
player.frame_ts and player.frame_index like it is done in set_frame_ts()
and we set directly player.frame_time using sxplayer_frame.ts without
aligning it with the specified framerate.

This fixes frames going backward after stepping forward using
sxplayer_get_next_frame() when the framerate is not aligned with the
actual frame timestamps.