### PR TITLE
mod_decoding: add missing <libavutil/channel_layout.h> include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix build with FFmpeg >= 5.0
 
 ## [9.11.0] - 2021-12-16
 ### Added

--- a/src/mod_decoding.c
+++ b/src/mod_decoding.c
@@ -20,6 +20,7 @@
 
 #include <libavutil/pixdesc.h>
 #include <libavutil/opt.h>
+#include <libavutil/channel_layout.h>
 
 #include "mod_decoding.h"
 #include "decoders.h"


### PR DESCRIPTION
av_get_channel_layout_string() is declared by
libavutil/channel_layout.h.

Fixes the following build error with FFmpeg 5.0:

 mod_decoding.c:122:5: error: implicit declaration of function
 'av_get_channel_layout_string' is invalid in C99