### PR TITLE
gitignore: ignore builddir folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+builddir


### PR DESCRIPTION
builddir is the recommended build directory and its name is hardcoded in .clangd file
